### PR TITLE
Update runtime and OARS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build_dir/
+build-dir/
 .flatpak-builder/

--- a/com.scoutshonour.Digital.appdata.xml
+++ b/com.scoutshonour.Digital.appdata.xml
@@ -27,7 +27,7 @@
     </p>
   </description>
 
-​  <launchable type="desktop-id">com.scoutshonour.Digital.desktop</launchable>
+  <launchable type="desktop-id">com.scoutshonour.Digital.desktop</launchable>
 
   <categories>
     <category>Game</category>
@@ -42,11 +42,8 @@
 
   <content_rating type="oars-1.1">
     <content_attribute id="violence-bloodshed">mild</content_attribute>
-    <content_attribute id="sex-homosexuality">mild</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
   </content_rating>
-
-
 
   <url type="homepage">http://scoutshonour.com/digital/</url>
   <developer_name>Christine Love</developer_name>

--- a/com.scoutshonour.Digital.yaml
+++ b/com.scoutshonour.Digital.yaml
@@ -1,6 +1,6 @@
 app-id: com.scoutshonour.Digital
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 command: Digital.sh
 finish-args:
@@ -17,11 +17,11 @@ add-extensions:
   # Support 32-bit python
   'org.freedesktop.Platform.Compat.i386':
     directory: 'lib/i386-linux-gnu'
-    version: '19.08'
+    version: '21.08'
 
   'org.freedesktop.Platform.Compat.i386.Debug':
     directory: 'lib/debug/lib/i386-linux-gnu'
-    version: '19.08'
+    version: '21.08'
     no-autodownload: true
 
 modules:


### PR DESCRIPTION
Updates the runtime to version 21.08 and removes the `sex-homosexuality` info from OARS metadata.