### PR TITLE
Update to runtime fdo 23.08

### DIFF
--- a/com.scoutshonour.Digital.desktop
+++ b/com.scoutshonour.Digital.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
-Version=1.1
+Version=1.5
 Name=Digital: A Love Story
 Exec=Digital.sh
 Icon=com.scoutshonour.Digital
-Categories=Game;AdventureGame
+Categories=Game;AdventureGame;

--- a/com.scoutshonour.Digital.metainfo.xml
+++ b/com.scoutshonour.Digital.metainfo.xml
@@ -29,16 +29,23 @@
 
   <launchable type="desktop-id">com.scoutshonour.Digital.desktop</launchable>
 
-  <categories>
-    <category>Game</category>
-    <category>AdventureGame</category>
-  </categories>
-
   <screenshots>
     <screenshot type="default">
       <image type="source">http://scoutshonour.com/digital/full.png</image>
     </screenshot>
   </screenshots>
+
+  <requires>
+    <internet>offline-only</internet>
+  </requires>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </recommends>
+
+  <releases>
+    <release version="1.1" date="2010-02-28" />
+  </releases>
 
   <content_rating type="oars-1.1">
     <content_attribute id="violence-bloodshed">mild</content_attribute>
@@ -46,23 +53,8 @@
   </content_rating>
 
   <url type="homepage">http://scoutshonour.com/digital/</url>
-  <developer_name>Christine Love</developer_name>
+  <url type="contact">https://loveconquersallgam.es/</url>
 
-  <releases>
-    <release version="1.1" date="2010-02-28">
-      <artifacts>
-          <artifact type="binary" platform="i386-linux-gnu">
-            <location>http://www.scoutshonour.com/lilyofthevalley/digital-1.1.tar.bz2</location>
-            <checksum type="sha256">e84f5245ca5b348fad3a25b272d55b839a6348501d3e876290c23f8ad4ff0201</checksum>
-            <size type="download">36981254</size>
-          </artifact>
-          <artifact type="binary" platform="win32">
-            <location>http://www.scoutshonour.com/lilyofthevalley/digital-1.1.exe</location>
-            <checksum type="sha256">a94c4482d7138800f96b6d6358afdbc1a12e60b80d0a35a0213a9fb73fdb1f5d</checksum>
-            <size type="download">35890680</size>
-          </artifact>
-        </artifacts>
-    </release>
-  </releases>
+  <developer_name>Christine Love</developer_name>
 
 </component>

--- a/com.scoutshonour.Digital.yaml
+++ b/com.scoutshonour.Digital.yaml
@@ -64,9 +64,17 @@ modules:
       - install -Dm755 Digital.py ${FLATPAK_DEST}/Digital.py
       - install -Dm755 Digital-launcher.sh ${FLATPAK_DEST}/bin/Digital.sh
       - install -Dm644 README.html ${FLATPAK_DEST}/README.html
-      - install -Dm644 com.scoutshonour.Digital.appdata.xml ${FLATPAK_DEST}/share/appdata/com.scoutshonour.Digital.appdata.xml
+      - install -Dm644 com.scoutshonour.Digital.metainfo.xml ${FLATPAK_DEST}/share/metainfo/com.scoutshonour.Digital.metainfo.xml
       - install -Dm644 com.scoutshonour.Digital.desktop ${FLATPAK_DEST}/share/applications/com.scoutshonour.Digital.desktop
-      - install -Dm644 game/icon.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/com.scoutshonour.Digital.png
+      # Copied from ChibiTracker flatpak manifest
+      - |
+        ICON_IN='game/icon.png'
+        ICON_OUT='com.scoutshonour.Digital.png'
+        for s in {32,64,128,256,512} ; do
+          SIZE="${s}x${s}"
+          ffmpeg -y -i "${ICON_IN}" -update 1 -s "${SIZE}" -sws_flags neighbor "${ICON_OUT}"
+          install -p -Dm644 "${ICON_OUT}" -t "${FLATPAK_DEST}/share/icons/hicolor/${SIZE}/apps/"
+        done
     sources:
       - type: archive
         url: http://www.scoutshonour.com/lilyofthevalley/digital-1.1.tar.bz2
@@ -76,7 +84,7 @@ modules:
         path: Digital-launcher.sh
 
       - type: file
-        path: com.scoutshonour.Digital.appdata.xml
+        path: com.scoutshonour.Digital.metainfo.xml
 
       - type: file
         path: com.scoutshonour.Digital.desktop

--- a/com.scoutshonour.Digital.yaml
+++ b/com.scoutshonour.Digital.yaml
@@ -1,6 +1,9 @@
 app-id: com.scoutshonour.Digital
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: &runtime-version '23.08'
+x-gl-version: &gl-version '1.4'
+x-gl-versions: &gl-versions 23.08;23.08-extra;1.4
+x-gl-merge-dirs: &gl-merge-dirs vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
 sdk: org.freedesktop.Sdk
 command: Digital.sh
 finish-args:
@@ -15,31 +18,55 @@ finish-args:
 
 add-extensions:
   # Support 32-bit python
-  'org.freedesktop.Platform.Compat.i386':
-    directory: 'lib/i386-linux-gnu'
-    version: '21.08'
+  org.freedesktop.Platform.Compat.i386:
+    directory: lib/i386-linux-gnu
+    version: *runtime-version
 
-  'org.freedesktop.Platform.Compat.i386.Debug':
-    directory: 'lib/debug/lib/i386-linux-gnu'
-    version: '21.08'
+  org.freedesktop.Platform.Compat.i386.Debug:
+    directory: lib/debug/lib/i386-linux-gnu
+    version: *runtime-version
     no-autodownload: true
+
+  # Support OpenGL for 32-bits
+  org.freedesktop.Platform.GL32:
+    directory: lib/i386-linux-gnu/GL
+    version: *gl-version
+    versions: *gl-versions
+    subdirectories: true
+    no-autodownload: true
+    autodelete: false
+    add-ld-path: lib
+    merge-dirs: *gl-merge-dirs
+    download-if: active-gl-driver
+    enable-if: active-gl-driver
+    autoprune-unless: active-gl-driver
+
+  org.freedesktop.Platform.GL32.Debug:
+    directory: lib/debug/lib/i386-linux-gnu/GL
+    version: *gl-version
+    versions: *gl-versions
+    subdirectories: true
+    no-autodownload: true
+    merge-dirs: *gl-merge-dirs
+    enable-if: active-gl-driver
+    autoprune-unless: active-gl-driver
 
 modules:
   - name: digital
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/lib/i386-linux-gnu
-      - install -Dm644 -t /app/etc ld.so.conf
-      - cp -R common /app/common
-      - cp -R game /app/game
-      - cp -R lib/* /app/lib
-      - cp -R renpy /app/renpy
-      - install -Dm755 Digital.py /app/Digital.py
-      - install -Dm755 Digital-launcher.sh /app/bin/Digital.sh
-      - install -Dm644 README.html /app/README.html
-      - install -Dm644 com.scoutshonour.Digital.appdata.xml /app/share/appdata/com.scoutshonour.Digital.appdata.xml
-      - install -Dm644 com.scoutshonour.Digital.desktop /app/share/applications/com.scoutshonour.Digital.desktop
-      - install -Dm644 game/icon.png /app/share/icons/hicolor/128x128/apps/com.scoutshonour.Digital.png
+      - mkdir -p ${FLATPAK_DEST}/lib/i386-linux-gnu
+      - install -Dm644 -t ${FLATPAK_DEST}/etc ld.so.conf
+      - cp -R common ${FLATPAK_DEST}/common
+      - cp -R game ${FLATPAK_DEST}/game
+      - cp -R lib/* ${FLATPAK_DEST}/lib
+      - cp -R renpy ${FLATPAK_DEST}/renpy
+      - install -Dm755 Digital.py ${FLATPAK_DEST}/Digital.py
+      - install -Dm755 Digital-launcher.sh ${FLATPAK_DEST}/bin/Digital.sh
+      - install -Dm644 README.html ${FLATPAK_DEST}/README.html
+      - install -Dm644 com.scoutshonour.Digital.appdata.xml ${FLATPAK_DEST}/share/appdata/com.scoutshonour.Digital.appdata.xml
+      - install -Dm644 com.scoutshonour.Digital.desktop ${FLATPAK_DEST}/share/applications/com.scoutshonour.Digital.desktop
+      - install -Dm644 game/icon.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/com.scoutshonour.Digital.png
     sources:
       - type: archive
         url: http://www.scoutshonour.com/lilyofthevalley/digital-1.1.tar.bz2

--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,1 +1,2 @@
- /app/lib/i386-linux-gnu
+/app/lib32
+/app/lib/i386-linux-gnu


### PR DESCRIPTION
This brings the game up to FreeDesktop 23.08 along with a few extra changes:

* A few updates to AppStream data (reordering, addition of unneeded values and addition of a few more)
* Scaled icons for several sizes
* Support for OpenGL with the GL32 extension
* Some misc improvements to manifest